### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,7 @@ ZbusMsg zbusMsg;
 For enum this looks like:
 
 ```c
-typedef enum
-{
+typedef enum {
     ENUM_VAL_00 = 0;
     ENUM_VAL_01;
     ENUM_VAL_02;


### PR DESCRIPTION
Fixed format for `typedef enum`, saying this. I prefer to stay away from  `typedef`s for structs, enums so that you know right away what you're deaing with (by using the specifier ahead of the custom name). Otherwise you need need to study all the types or go look up what exactly `My_type` was again....that can be very annoying. Saying this, I respect your opinion too  :smile: